### PR TITLE
Applies names to sessions, windows, and panes.

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,16 +74,20 @@ func shellInDir(dir, cmd string) {
 }
 
 func NewWindow(session *Session, window *Window, dir string) {
+	var namedWindow string
+	if(len(window.Name) > 0) {
+		namedWindow = fmt.Sprintf(`-n "%s"`, window.Name)
+	}
 	if session.started {
-		shell("tmux new-window -d -t %s -n %s -c %s", session.Name, window.Name, dir)
+		shell("tmux new-window -d -t %s %s -c %s", session.Name, namedWindow, dir)
 	} else {
-		shell("tmux new-session -d -s %s -n %s -c %s", session.Name, window.Name, dir)
+		shell("tmux new-session -d -s %s %s -c %s", session.Name, namedWindow, dir)
 		session.started = true
 	}
 }
 
-func NewPane(target, pane *Pane, dir string) {
-	shell("tmux split-window -t %s -n %s -c %s", target, pane.Name, dir)
+func NewPane(target, dir string) {
+	shell("tmux split-window -t %s -c %s", target, dir)
 }
 
 func SelectWindow(target string) {
@@ -241,7 +245,7 @@ func (project *Project) up() {
 				p.target = fmt.Sprintf("%s:%d.%d", s.Name, wi, pi)
 				dir := project.getDir(s, w, pi)
 				if pi > 0 {
-					NewPane(target, p, dir)
+					NewPane(target, dir)
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -73,17 +73,17 @@ func shellInDir(dir, cmd string) {
 	shell("cd %s;%s", coalesce(dir, "."), cmd)
 }
 
-func NewWindow(session *Session, dir string) {
+func NewWindow(session *Session, window *Window, dir string) {
 	if session.started {
-		shell("tmux new-window -d -t %s -c %s", session.Name, dir)
+		shell("tmux new-window -d -t %s -n %s -c %s", session.Name, window.Name, dir)
 	} else {
-		shell("tmux new-session -d -s %s -c %s", session.Name, dir)
+		shell("tmux new-session -d -s %s -n %s -c %s", session.Name, window.Name, dir)
 		session.started = true
 	}
 }
 
-func NewPane(target, dir string) {
-	shell("tmux split-window -t %s -c %s", target, dir)
+func NewPane(target, pane *Pane, dir string) {
+	shell("tmux split-window -t %s -n %s -c %s", target, pane.Name, dir)
 }
 
 func SelectWindow(target string) {
@@ -232,7 +232,7 @@ func (project *Project) up() {
 			target := fmt.Sprintf("%s:%d", s.Name, wi)
 			dir := project.getDir(s, w, 0)
 
-			NewWindow(s, dir)
+			NewWindow(s, w, dir)
 
 			for pi, p := range w.Panes {
 				if p == nil {
@@ -241,7 +241,7 @@ func (project *Project) up() {
 				p.target = fmt.Sprintf("%s:%d.%d", s.Name, wi, pi)
 				dir := project.getDir(s, w, pi)
 				if pi > 0 {
-					NewPane(target, dir)
+					NewPane(target, p, dir)
 				}
 			}
 


### PR DESCRIPTION
This is untested. I just know that `-n` is the flag you need to name a window or a pane. Likely you'll want some extra logic to make sure that the name actually exists in the YML and I guess the session doesn't necessarily need to be named? Or it's named already? I don't know. I'm a tmux noob.